### PR TITLE
SelectManager#from expects a Arel Join node object

### DIFF
--- a/lib/ransack/adapters/active_record/context.rb
+++ b/lib/ransack/adapters/active_record/context.rb
@@ -106,8 +106,8 @@ module Ransack
                 @join_dependency.join_constraints(@object.joins_values)
               ]
             end
-            joins.each do |aliased_join|
-              base.from(aliased_join)
+            joins.first.each do |aliased_join|
+              base.from(aliased_join.first)
             end
             base.join_sources
           end


### PR DESCRIPTION
* SelectManager#from expects a Arel Join node object

https://github.com/rails/arel/blob/v6.0.4/lib/arel/select_manager.rb#L91
